### PR TITLE
 Reduce PINGREQ frequency to KeepAliveInterval at a maximum

### DIFF
--- a/MqttLib/Mqtt.cs
+++ b/MqttLib/Mqtt.cs
@@ -166,7 +166,7 @@ namespace MqttLib
                 manager.WaitForResponse();
                 TimerCallback callback = new TimerCallback(tmrCallback);
                 // TODO: Set Keep Alive interval and keepAlive time as property of client
-                int keepAliveInterval = 1000 * (_keepAlive / 3);
+                int keepAliveInterval = 1000 * _keepAlive;
                 keepAliveTimer = new Timer(callback, null, keepAliveInterval, keepAliveInterval);
             }
             catch (Exception e)
@@ -191,6 +191,12 @@ namespace MqttLib
         {
             if (manager.IsConnected)
             {
+                // Reset the PINGREQ timer as this publish will reset the server's counter
+                if (keepAliveTimer != null)
+                {
+                    int kmillis = 1000 * _keepAlive;
+                    keepAliveTimer.Change(kmillis, kmillis);
+                }
                 ushort messID = MessageID;
                 manager.SendMessage(new MqttPublishMessage(messID, topic, payload.TrimmedBuffer, qos, retained));
                 return messID;


### PR DESCRIPTION
The Mqtt client was sending PINGREQ messages every KeepAliveInterval / 3
seconds, regardless of any client publish activity. The v3.1 spec states
that the server expects at least one message per KeepAlive interval and
allows a 50% grace period after that before the client is disconnected.

This patch reduces write actitivy so that a PINGREQ timer is reset on
PUBLISH, meaning a ping is only sent if a publish hasn't been sent in the
past KeepAliveInterval seconds.
