### PR TITLE
file logging can be turned off

### DIFF
--- a/MqttLib/Logger/Log.cs
+++ b/MqttLib/Logger/Log.cs
@@ -8,6 +8,13 @@ namespace MqttLib.Logger
     {
       private static ILog _log = null;
 
+      public static bool LoggingEnabled { get; set; }
+
+      static Log()
+      {
+          LoggingEnabled = true;
+      }
+
       public static ILog CreateLog(string name)
       {
         if (_log == null) { _log = new FileLog(name); }
@@ -22,14 +29,20 @@ namespace MqttLib.Logger
 
       public static void Write(string message)
       {
+        if (LoggingEnabled)
+        {
           if (_log == null) { CreateLog("Unknown"); }
           _log.Write(message);
+        }
       }
 
       public static void Write(LogLevel level, string message)
       {
+        if (LoggingEnabled)
+        {
           if (_log == null) { CreateLog("Unknown"); }
           _log.Write(level, message);
+        }
       }
     }
 }

--- a/MqttLib/Mqtt.cs
+++ b/MqttLib/Mqtt.cs
@@ -46,7 +46,7 @@ namespace MqttLib
             set { qosManager.ResendInterval = value; }
         }
 
-        public Mqtt(string connString, string clientID, string username, string password, IPersistence store)
+        public Mqtt(string connString, string clientID, string username, string password, IPersistence store, bool enableLogging)
         {
             _store = store;
             qosManager = new QoSManager(_store);
@@ -55,6 +55,7 @@ namespace MqttLib
             _clientID = clientID;
             _username = username;
             _password = password;
+            Log.LoggingEnabled = enableLogging;
         }
 
         void tmrCallback(object args)

--- a/MqttLib/MqttClientFactory.cs
+++ b/MqttLib/MqttClientFactory.cs
@@ -7,17 +7,17 @@ namespace MqttLib
 {
     public class MqttClientFactory
     {
-        public static IMqtt CreateClient(string connString, string clientId, string username = null, string password = null, IPersistence persistence = null)
+        public static IMqtt CreateClient(string connString, string clientId, string username = null, string password = null, IPersistence persistence = null, bool enableLogging = true)
         {
-            return new Mqtt(connString, clientId, username, password, persistence);
+            return new Mqtt(connString, clientId, username, password, persistence, enableLogging);
         }
 
-        public static IMqttShared CreateSharedClient(string connString, string clientId, string username = null, string password = null)
+        public static IMqttShared CreateSharedClient(string connString, string clientId, string username = null, string password = null, bool enableLogging = true)
         {
-            return new Mqtt(connString, clientId, username, password, null);
+            return new Mqtt(connString, clientId, username, password, null, enableLogging);
         }
 
-        public static IMqtt CreateBufferedClient(string connString, string clientId)
+        public static IMqtt CreateBufferedClient(string connString, string clientId, bool enableLogging = true)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Using the library multiple times in a multuithreaded application leads to problems due to all instances logging to the same file. With this changes the logging is by default switched on but it can be dsiabled if not needed.
